### PR TITLE
example: add import inlining failure case

### DIFF
--- a/examples/import-inlining-failure/README.md
+++ b/examples/import-inlining-failure/README.md
@@ -1,0 +1,54 @@
+# Import Inlining Failure Example
+
+This example demonstrates a case where import inlining fails with "Module file not found"
+even though the Mathlib source files are present in `.lake/packages/mathlib/`.
+
+## Setup
+
+```bash
+# From the root of the lean-minimizer repo:
+echo "leanprover/lean4:nightly-2026-01-23" > lean-toolchain
+
+# Add to lakefile.toml:
+# [[require]]
+# name = "mathlib"
+# git = "https://github.com/leanprover-community/mathlib4-nightly-testing"
+# rev = "nightly-testing"
+
+lake update
+lake exe cache get
+lake build minimize
+```
+
+## Reproduce
+
+```bash
+lake exe minimize examples/import-inlining-failure/simp_test.lean
+```
+
+## Expected behavior
+
+The minimizer should inline the `Mathlib.Algebra.Group.Torsion` import and produce
+a self-contained Lean file with no external dependencies.
+
+## Actual behavior
+
+```
+[Pass 12] Running: Import Inlining
+  Analyzing 1 imports for inlining...
+  Trying to inline import Mathlib.Algebra.Group.Torsion...
+    Module file not found, skipping
+  No imports could be inlined
+```
+
+The Mathlib source files ARE present at `.lake/packages/mathlib/Mathlib/Algebra/Group/Torsion.lean`.
+
+## Context
+
+This test case is for bisecting a simp perm lemma regression in Lean 4.
+The goal is to produce a Mathlib-free file that demonstrates:
+- `simp [zsmul_comm _ z]` succeeds (with explicit args)
+- `simp [zsmul_comm]` fails (without explicit args, treated as perm lemma)
+
+Once minimized, the file can be used with `lean-bisect` to find the exact
+Lean 4 commit that caused the behavior change.

--- a/examples/import-inlining-failure/simp_test.lean
+++ b/examples/import-inlining-failure/simp_test.lean
@@ -1,0 +1,60 @@
+/-
+Test case for simp perm lemma regression.
+
+On nightly-2026-01-23:
+- `simp [zsmul_comm _ z]` succeeds (explicit args, not a perm lemma)
+- `simp [zsmul_comm]` fails (perm lemma, AC ordering rejects)
+
+This file demonstrates the bug. When minimized, import inlining fails with
+"Module file not found" even though Mathlib source files are present in
+.lake/packages/mathlib/.
+-/
+import Mathlib.Algebra.Group.Torsion
+
+namespace SimpTest
+
+variable {G : Type*} [AddCommGroup G] {a b p : G} {z : ℤ}
+
+def ModEq (a b p : G) : Prop := ∃ m : ℤ, m • p = b - a
+notation:50 a " ≡ " b " [PMOD " p "]" => ModEq a b p
+lemma modEq_iff_zsmul : a ≡ b [PMOD p] ↔ ∃ m : ℤ, m • p = b - a := Iff.rfl
+
+-- SUCCESS: With explicit args, zsmul_comm is not a perm lemma
+#guard_msgs in
+theorem test_success [IsAddTorsionFree G] (hn : z ≠ 0) :
+    z • a ≡ z • b [PMOD z • p] ↔ a ≡ b [PMOD p] := by
+  simp [modEq_iff_zsmul, ← zsmul_sub, zsmul_comm _ z, zsmul_right_inj hn]
+
+-- FAILURE: Without explicit args, zsmul_comm becomes a perm lemma and is rejected
+/--
+error: unsolved goals
+G : Type u_1
+inst✝¹ : AddCommGroup G
+a b p : G
+z : ℤ
+inst✝ : IsAddTorsionFree G
+hn : z ≠ 0
+⊢ (∃ m, m • z • p = z • (b - a)) ↔ ∃ m, m • p = b - a
+---
+warning: This simp argument is unused:
+  zsmul_comm
+
+Hint: Omit it from the simp argument list.
+  simp [modEq_iff_zsmul, ← zsmul_sub, zsmul_c̵o̵m̵m̵,̵ ̵z̵s̵m̵u̵l̵_̵right_inj hn]
+
+Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
+---
+warning: This simp argument is unused:
+  zsmul_right_inj hn
+
+Hint: Omit it from the simp argument list.
+  simp [modEq_iff_zsmul, ← zsmul_sub, zsmul_comm,̵ ̵z̵s̵m̵u̵l̵_̵r̵i̵g̵h̵t̵_̵i̵n̵j̵ ̵h̵n̵]
+
+Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
+-/
+#guard_msgs in
+theorem test_failure [IsAddTorsionFree G] (hn : z ≠ 0) :
+    z • a ≡ z • b [PMOD z • p] ↔ a ≡ b [PMOD p] := by
+  simp [modEq_iff_zsmul, ← zsmul_sub, zsmul_comm, zsmul_right_inj hn]
+
+end SimpTest


### PR DESCRIPTION
This PR adds an example that demonstrates a case where import inlining fails with "Module file not found" even though the Mathlib source files are present in `.lake/packages/mathlib/`.

## The Issue

When running `lake exe minimize` on a file that imports `Mathlib.Algebra.Group.Torsion`, the import inlining pass reports:

```
[Pass 12] Running: Import Inlining
  Analyzing 1 imports for inlining...
  Trying to inline import Mathlib.Algebra.Group.Torsion...
    Module file not found, skipping
```

The source file IS present at `.lake/packages/mathlib/Mathlib/Algebra/Group/Torsion.lean`.

## Setup to Reproduce

```bash
echo "leanprover/lean4:nightly-2026-01-23" > lean-toolchain

# Add to lakefile.toml:
# [[require]]
# name = "mathlib"
# git = "https://github.com/leanprover-community/mathlib4-nightly-testing"
# rev = "nightly-testing"

lake update
lake exe cache get
lake build minimize
lake exe minimize examples/import-inlining-failure/simp_test.lean
```

## Context

This test case is for bisecting a simp perm lemma regression in Lean 4. The goal is to produce a Mathlib-free file that can be used with `lean-bisect`.

🤖 Prepared with Claude Code