### PR TITLE
Extract and use leanOptions from lakefile when testing compilation

### DIFF
--- a/LeanMinimizer.lean
+++ b/LeanMinimizer.lean
@@ -4,6 +4,7 @@ import LeanMinimizer.Basic
 import LeanMinimizer.Dependencies
 import LeanMinimizer.Subprocess
 import LeanMinimizer.Pass
+import LeanMinimizer.LakefileOptions
 import LeanMinimizer.Passes.ModuleRemoval
 import LeanMinimizer.Passes.Deletion
 import LeanMinimizer.Passes.EmptyScopeRemoval

--- a/LeanMinimizer/Basic.lean
+++ b/LeanMinimizer/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 import Lean.Elab.Frontend
 import Lean.Elab.Command
 import Lean.Util.Path
+import LeanMinimizer.LakefileOptions
 
 /-!
 # Minimize: A Lean test case minimizer
@@ -470,11 +471,14 @@ def testCompilesSubprocess (source : String) (fileName : String) : IO Bool := do
     ("PATH", path)
   ]
 
+  -- Get leanOptions from the project's lakefile
+  let leanOptions ← getLeanOptionsForFile fileName
+
   -- Run lean to check compilation, with try/finally for cleanup
   try
     let result ← IO.Process.output {
       cmd := "lean"
-      args := #[tempFile.toString]
+      args := leanOptions ++ #[tempFile.toString]
       env := env
     }
     return result.exitCode == 0
@@ -501,11 +505,14 @@ def testCompilesSubprocessWithError (source : String) (fileName : String) : IO (
     ("PATH", path)
   ]
 
+  -- Get leanOptions from the project's lakefile
+  let leanOptions ← getLeanOptionsForFile fileName
+
   -- Run lean to check compilation, with try/finally for cleanup
   try
     let result ← IO.Process.output {
       cmd := "lean"
-      args := #[tempFile.toString]
+      args := leanOptions ++ #[tempFile.toString]
       env := env
     }
     let success := result.exitCode == 0

--- a/LeanMinimizer/LakefileOptions.lean
+++ b/LeanMinimizer/LakefileOptions.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Lean
+
+/-!
+# Extract leanOptions from lakefile configuration
+
+This module provides utilities to extract leanOptions from a project's lakefile
+and convert them to command-line arguments for the `lean` command.
+-/
+
+namespace LeanMinimizer
+
+open System (FilePath)
+
+/-- Find the project root by searching upward for lakefile.toml or lakefile.lean -/
+partial def findProjectRootForOptions (startPath : FilePath) : IO (Option FilePath) := do
+  let lakefileToml := startPath / "lakefile.toml"
+  let lakefileLean := startPath / "lakefile.lean"
+
+  if (← lakefileToml.pathExists) || (← lakefileLean.pathExists) then
+    return some startPath
+  else
+    match startPath.parent with
+    | none => return none
+    | some parent => findProjectRootForOptions parent
+
+/-- Find the index of a character in a string, returns none if not found -/
+def findCharInString (s : String) (c : Char) : Option Nat :=
+  s.toList.findIdx? (· == c)
+
+/-- Extract substring between start and end indices -/
+def substringBetween (s : String) (startIdx endIdx : Nat) : String :=
+  String.ofList (s.toList.drop (startIdx + 1) |>.take (endIdx - startIdx - 1))
+
+/-- Parse lakefile.toml and extract leanOptions as an array of -D arguments.
+    Returns command-line arguments like #["-DmaxSynthPendingDepth=3", "-DautoImplicit=false"]. -/
+def getLeanOptionsFromToml (projectRoot : FilePath) : IO (Array String) := do
+  let lakefilePath := projectRoot / "lakefile.toml"
+
+  -- Check if lakefile.toml exists
+  unless ← lakefilePath.pathExists do
+    return #[]
+
+  -- Read the TOML file
+  let content ← IO.FS.readFile lakefilePath
+
+  -- Parse TOML manually for leanOptions
+  -- We'll look for lines like "leanOptions = {key = value, ...}"
+  let mut leanArgs := #[]
+
+  for line in content.splitOn "\n" do
+    let trimmed := line.trimAscii.toString
+    if trimmed.startsWith "leanOptions" then
+      -- Extract the inline table: {key1 = val1, key2 = val2}
+      if let some startIdx := findCharInString trimmed '{' then
+        if let some endIdx := findCharInString trimmed '}' then
+          let tableContent := (substringBetween trimmed startIdx endIdx).trimAscii.toString
+
+          -- Split by commas to get individual key=value pairs
+          for pair in tableContent.splitOn "," do
+            let pair := pair.trimAscii.toString
+            if let some eqIdx := findCharInString pair '=' then
+              let key := (String.ofList (pair.toList.take eqIdx)).trimAscii.toString
+              let value := (String.ofList (pair.toList.drop (eqIdx + 1))).trimAscii.toString
+              -- Convert to -D argument
+              leanArgs := leanArgs.push s!"-D{key}={value}"
+
+  return leanArgs
+
+/-- Get lean options for a file by finding its project root and extracting options.
+    Returns an array of -D arguments to pass to the lean command. -/
+def getLeanOptionsForFile (fileName : String) : IO (Array String) := do
+  let fp := FilePath.mk fileName
+  let absoluteFilePath ← do
+    if fp.isAbsolute then pure fp
+    else do
+      let cwd ← IO.currentDir
+      pure (cwd / fp)
+
+  let startPath := absoluteFilePath.parent.getD (← IO.currentDir)
+
+  match ← findProjectRootForOptions startPath with
+  | none => return #[]
+  | some root => getLeanOptionsFromToml root
+
+end LeanMinimizer

--- a/LeanMinimizer/Passes/ExtendsSimplification.lean
+++ b/LeanMinimizer/Passes/ExtendsSimplification.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import LeanMinimizer.Pass
+import LeanMinimizer.LakefileOptions
 
 /-!
 # Extends Clause Simplification Pass
@@ -174,12 +175,15 @@ def runLeanOnSource (source : String) (fileName : String) : IO (UInt32 × String
     ("PATH", path)
   ]
 
+  -- Get leanOptions from the project's lakefile
+  let leanOptions ← getLeanOptionsForFile fileName
+
   let cwd := (System.FilePath.mk fileName).parent.getD (System.FilePath.mk ".")
   -- Run lean with try/finally for cleanup
   try
     let result ← IO.Process.output {
       cmd := "lean"
-      args := #[tempFile.toString]
+      args := leanOptions ++ #[tempFile.toString]
       env := env
       cwd := some cwd
     }

--- a/LeanMinimizer/Passes/StructureFieldRemoval.lean
+++ b/LeanMinimizer/Passes/StructureFieldRemoval.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import LeanMinimizer.Pass
+import LeanMinimizer.LakefileOptions
 
 /-!
 # Structure Field Removal Pass
@@ -209,11 +210,14 @@ def runLeanOnSourceForField (source : String) (fileName : String) : IO (UInt32 �
     ("PATH", path)
   ]
 
+  -- Get leanOptions from the project's lakefile
+  let leanOptions ← getLeanOptionsForFile fileName
+
   let cwd := (System.FilePath.mk fileName).parent.getD (System.FilePath.mk ".")
   try
     let result ← IO.Process.output {
       cmd := "lean"
-      args := #[tempFile.toString]
+      args := leanOptions ++ #[tempFile.toString]
       env := env
       cwd := some cwd
     }


### PR DESCRIPTION
This PR fixes an issue where the minimizer would report files as failing to compile even though they build successfully with `lake build`.

## Problem

When testing if files compile, the minimizer was calling `lean` directly without passing any leanOptions configured in the project's lakefile. This caused false failures when projects set options like `maxSynthPendingDepth = 3` (as Mathlib does), because the minimizer would test with Lean's default values instead.

## Solution

The minimizer now:
1. Finds the project root by searching upward for `lakefile.toml` or `lakefile.lean`
2. Parses `lakefile.toml` to extract `leanOptions` (e.g., `maxSynthPendingDepth = 3`)
3. Passes them as `-D` arguments when running `lean` to test compilation

## Changes

- Added new module `LakefileOptions.lean` to parse lakefile.toml and extract leanOptions
- Updated compilation testing in:
  - `Basic.lean`: `testCompilesSubprocess` and `testCompilesSubprocessWithError`
  - `StructureFieldRemoval.lean`: `runLeanOnSourceForField`
  - `ExtendsSimplification.lean`: `runLeanOnSource`

## Testing

Verified with mathlib-minimizer that files using inlined Mathlib imports now correctly compile when tested by the minimizer, matching the behavior of `lake build`.

Related Zulip discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/interesting.20problem.20with.20Mathlib.20minimization/near/570221277

🤖 Prepared with Claude Code