### PR TITLE
chore: bump toolchain to v4.28.0-rc1

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0-rc1
+leanprover/lean4:v4.28.0-rc1


### PR DESCRIPTION
Bump lean-toolchain from v4.27.0-rc1 to v4.28.0-rc1.

🤖 Prepared with Claude Code