### PR TITLE
feat: add --git flag to commit after each minimization step

### DIFF
--- a/LeanMinimizer/Basic.lean
+++ b/LeanMinimizer/Basic.lean
@@ -125,6 +125,11 @@ Options:
       --only-import-minimization  Import minimization
       --only-import-inlining   Import inlining
 
+  --git
+    Commit to git after each minimization step that makes a change.
+    The workspace must already be a git repo. Each commit uses a message
+    describing which pass made the change.
+
   --help
     Show this help message.
 
@@ -209,6 +214,8 @@ structure Args where
   /-- Cross-version minimization: a second toolchain where the file must also compile.
       Use with #elab_if to encode version-specific expectations in the file itself. -/
   crossToolchain : Option String := none
+  /-- Commit to git after each pass that makes a change -/
+  gitCommit : Bool := false
 
 /-- Check if verbose output is enabled (default is verbose, --quiet disables) -/
 def Args.verbose (args : Args) : Bool := !args.quiet
@@ -249,6 +256,7 @@ def parseArgs (args : List String) : Except String Args := do
     | "--only-extends" :: rest => go rest { acc with onlyPass := some "extends" }
     | "--only-attr-expansion" :: rest => go rest { acc with onlyPass := some "attr-expansion" }
     | "--only-empty-scope" :: rest => go rest { acc with onlyPass := some "empty-scope" }
+    | "--git" :: rest => go rest { acc with gitCommit := true }
     | "--resume" :: rest => go rest { acc with resume := true }
     | "--cross-toolchain" :: tc :: rest => go rest { acc with crossToolchain := some tc }
     | "--cross-toolchain" :: [] => .error "--cross-toolchain requires an argument"

--- a/LeanMinimizer/Pass.lean
+++ b/LeanMinimizer/Pass.lean
@@ -284,6 +284,18 @@ def SubprocessPassResult.toPassResult (result : SubprocessPassResult) : PassResu
   { source := result.source, changed := result.changed, action,
     newFailedChanges := result.newFailedChanges, clearMemory := result.clearMemory }
 
+/-- Commit the current state of the output file to git with a message describing the pass. -/
+def gitCommitPass (outputFile : String) (passName : String) : IO Unit := do
+  -- Find the directory containing the output file
+  let dir := (System.FilePath.mk outputFile).parent.getD "."
+  let run (args : Array String) : IO Bool := do
+    let r ← IO.Process.output { cmd := "git", args, cwd := dir }
+    return r.exitCode == 0
+  -- Stage the output file and commit
+  if ← run #["add", outputFile] then
+    discard <| run #["commit", "-m", s!"minimize: {passName}",
+      "--author", "minimize <minimize@localhost>"]
+
 /-- Run passes in sequence according to their on-success actions.
     Uses subprocess-based elaboration to avoid [init] conflicts.
 
@@ -305,7 +317,8 @@ unsafe def runPasses (passes : Array Pass) (input : String)
     (completeSweepBudget : Float := 0.20)
     (initialStableSections : Std.HashSet String := {})
     (initialTopmostEndIdx : Option Nat := none)
-    (crossToolchain : Option String := none) : IO String := do
+    (crossToolchain : Option String := none)
+    (gitCommit : Bool := false) : IO String := do
   if passes.isEmpty then
     return input
 
@@ -457,6 +470,8 @@ unsafe def runPasses (passes : Array Pass) (input : String)
     -- Write updated source to output file if specified
     if let some outPath := outputFile then
       IO.FS.writeFile outPath source
+      if gitCommit then
+        gitCommitPass outPath pass.name
 
     match result.action with
     | .restart =>

--- a/Main.lean
+++ b/Main.lean
@@ -365,7 +365,7 @@ unsafe def main (args : List String) : IO UInt32 := do
       let _ ← runPasses passes input inputFile parsedArgs.marker
                      parsedArgs.verbose (some outputFile)
                      parsedArgs.completeSweepBudget initialStableSections initialTopmostEndIdx
-                     parsedArgs.crossToolchain
+                     parsedArgs.crossToolchain parsedArgs.gitCommit
       IO.eprintln s!"Output written to {outputFile}"
       return 0
     catch e =>


### PR DESCRIPTION
This PR adds a `--git` flag to the minimizer. When enabled, it commits to git after each pass that makes a change, with a commit message identifying the pass (e.g. `minimize: Command Deletion`).

This makes it easy to review minimization progress with `git log --oneline` or `git diff HEAD~1`.

The workspace must already be a git repo. The companion `minimize` tool initializes workspaces as git repos.

🤖 Prepared with Claude Code